### PR TITLE
Ported to on Windows and Python 2.7

### DIFF
--- a/hikvision_tftpd.py
+++ b/hikvision_tftpd.py
@@ -51,7 +51,7 @@ _SERVER_IP = '192.0.0.128'
 _HANDSHAKE_SERVER_ADDR = (_SERVER_IP, 9978)
 _TFTP_SERVER_ADDR = (_SERVER_IP, 69)
 _FILENAME = 'digicap.dav'
-_TIME_FMT = '%T'
+_TIME_FMT = '%c'
 
 
 class Error(Exception): pass
@@ -160,7 +160,7 @@ class Server(object):
 
 if __name__ == '__main__':
     try:
-        file_contents = open(_FILENAME, 'r').read()
+        file_contents = open(_FILENAME, mode='rb').read()
     except IOError, e:
         print 'Error: can\'t read %s' % _FILENAME
         if e.errno == errno.ENOENT:

--- a/hikvision_tftpd_test.py
+++ b/hikvision_tftpd_test.py
@@ -78,7 +78,8 @@ class TftpdTest(unittest.TestCase):
             self.assertTrue('not available' in e.message, 'Unexpected: %r' % e)
         else:
             self.fail('expected an error')
-	# No skip check for user root on Windows Platform
+	
+	# Skip check for user root not relevant on Windows Platform
     @unittest.skipIf(sys.platform.startswith("win"), "Skip check for root permissions on Windows")
     def test_eaccess(self):
         try:

--- a/hikvision_tftpd_test.py
+++ b/hikvision_tftpd_test.py
@@ -11,6 +11,7 @@ import socket
 import string
 import unittest
 import platform
+import sys
 
 
 class TftpdTest(unittest.TestCase):
@@ -77,18 +78,16 @@ class TftpdTest(unittest.TestCase):
             self.assertTrue('not available' in e.message, 'Unexpected: %r' % e)
         else:
             self.fail('expected an error')
-
+	# No skip check for user root on Windows Platform
+    @unittest.skipIf(sys.platform.startswith("win"), "requires Windows")
     def test_eaccess(self):
-		# No check for root on Windows Platform
-		if platform.system() != 'Windows':
-			try:
-				# The test shouldn't be running as root.
-				hikvision_tftpd.Server(('127.0.0.1', 1), ('127.0.0.1', 3), '')
-			except hikvision_tftpd.Error, e:
-				self.assertTrue('permission' in e.message, 'Unexpected: %r' % e)
-			else:
-				self.fail('expected an error. '
-						  '(did you run the tests as root? don\'t.)')
+        try:
+            hikvision_tftpd.Server(('127.0.0.1', 1), ('127.0.0.1', 3), '')
+        except hikvision_tftpd.Error, e:
+            self.assertTrue('permission' in e.message, 'Unexpected: %r' % e)
+        else:
+            self.fail('expected an error. '
+					  '(did you run the tests as root? don\'t.)')
 
 
     def test_proper_handshake(self):

--- a/hikvision_tftpd_test.py
+++ b/hikvision_tftpd_test.py
@@ -10,6 +10,7 @@ import hikvision_tftpd
 import socket
 import string
 import unittest
+import platform
 
 
 class TftpdTest(unittest.TestCase):
@@ -78,14 +79,16 @@ class TftpdTest(unittest.TestCase):
             self.fail('expected an error')
 
     def test_eaccess(self):
-        try:
-            # The test shouldn't be running as root.
-            hikvision_tftpd.Server(('127.0.0.1', 1), ('127.0.0.1', 3), '')
-        except hikvision_tftpd.Error, e:
-            self.assertTrue('permission' in e.message, 'Unexpected: %r' % e)
-        else:
-            self.fail('expected an error. '
-                      '(did you run the tests as root? don\'t.)')
+		# No check for root on Windows Platform
+		if platform.system() != 'Windows':
+			try:
+				# The test shouldn't be running as root.
+				hikvision_tftpd.Server(('127.0.0.1', 1), ('127.0.0.1', 3), '')
+			except hikvision_tftpd.Error, e:
+				self.assertTrue('permission' in e.message, 'Unexpected: %r' % e)
+			else:
+				self.fail('expected an error. '
+						  '(did you run the tests as root? don\'t.)')
 
 
     def test_proper_handshake(self):

--- a/hikvision_tftpd_test.py
+++ b/hikvision_tftpd_test.py
@@ -79,7 +79,7 @@ class TftpdTest(unittest.TestCase):
         else:
             self.fail('expected an error')
 	# No skip check for user root on Windows Platform
-    @unittest.skipIf(sys.platform.startswith("win"), "requires Windows")
+    @unittest.skipIf(sys.platform.startswith("win"), "Skip check for root permissions on Windows")
     def test_eaccess(self):
         try:
             hikvision_tftpd.Server(('127.0.0.1', 1), ('127.0.0.1', 3), '')


### PR DESCRIPTION
I've done some modification to run your script on Windows.
hikvision_tftpd.py:_TIME_FMT changed from '%T' to '%c' and open digicap.dav in Binary mode. hikvision_tftpd_test.py: Check for User root skipped on windows.